### PR TITLE
Typo in script, GH action should fail.

### DIFF
--- a/sys-info.ps1
+++ b/sys-info.ps1
@@ -58,7 +58,7 @@ function Get-ProcessInfoTable {
 }
 
 function Get-ProcessInfoJson {
-    Get-ProcessWithUser | ConvertTo-Json
+    Get-ProcessWithser | ConvertTo-Json
 }
 function Show-Help {
     @"


### PR DESCRIPTION
This is an example PR to demonstrate that GH Action fails in Sanity Tests because of typo.